### PR TITLE
adding install of tensorboard

### DIFF
--- a/tensorflow/tools/ci_build/linux/mkl/Dockerfile.devel-mkl
+++ b/tensorflow/tools/ci_build/linux/mkl/Dockerfile.devel-mkl
@@ -68,6 +68,8 @@ RUN echo "import /root/.mkl.bazelrc" >>/root/.bazelrc
 # Install futures>=0.17.1 for Python2.7 compatibility mode
 RUN ${PIP} install future>=0.17.1
 
+RUN ${PIP} install tensorboard
+
 RUN bazel --bazelrc=/root/.bazelrc build -c opt \
     tensorflow/tools/pip_package:build_pip_package && \
     bazel-bin/tensorflow/tools/pip_package/build_pip_package "${TF_NIGHTLY_FLAG}" "${WHL_DIR}" && \


### PR DESCRIPTION
This change fixes nightly wheel build
https://tensorflow-ci.intel.com/view/Monitor%20These/job/tensorflow-mkl-build-whl-nightly/1062/console 
Once this is merged, I will modify the job to point to PublicCI. 