### PR TITLE
upgrade curl-8.4.0

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -510,10 +510,10 @@ def _tf_repositories():
     tf_http_archive(
         name = "curl",
         build_file = "//third_party:curl.BUILD",
-        sha256 = "d3a19aeea301085a56c32bc0f7d924a818a7893af253e41505d1e26d7db8e95a",
-        strip_prefix = "curl-8.3.0",
+        sha256 = "816e41809c043ff285e8c0f06a75a1fa250211bbfb2dc0a037eeef39f1a9e427",
+        strip_prefix = "curl-8.4.0",
         system_build_file = "//third_party/systemlibs:curl.BUILD",
-        urls = tf_mirror_urls("https://curl.haxx.se/download/curl-8.3.0.tar.gz"),
+        urls = tf_mirror_urls("https://curl.se/download/curl-8.4.0.tar.gz"),
     )
 
     # WARNING: make sure ncteisen@ and vpai@ are cc-ed on any CL to change the below rule


### PR DESCRIPTION
upgrade curl 8.3.0 -> 8.4.0 which has latest CVE fixed.  Build successfully on the branch https://cje-fm-owrp-prod04.devtools.intel.com/satg-aia-tf/view/release-testing/job/Tensorflow-Manylinux-Wheels-2.14/23/